### PR TITLE
Fix DAMASK development commit

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -3,7 +3,8 @@
 # clone latest development version of DAMASK 
 git clone https://github.com/eisenforschung/DAMASK.git
 cd DAMASK 
-git checkout -b development
+# git checkout -b development
+git checkout 264fab44
 patch -p1 < ../binder/python.patch
 
 # update python wrapper to latest development version 


### PR DESCRIPTION
The mysterious behavior was caused by changes in the development branch. When I created a fork of this repository DAMASK suddenly started to complain about the input. So for now I fixed the development commit then we have a stable reference to compare to when the next DAMASK version is released.